### PR TITLE
fix `TypeError` in `update_sys_path` method

### DIFF
--- a/plexhints/__init__.py
+++ b/plexhints/__init__.py
@@ -91,8 +91,10 @@ def update_sys_path():
     for directory in directory_tests:
         tmp_contents_path = list(contents_path)  # copy the original list
         while True:
-            tmp_dir = os.path.join(directory, os.path.join(*tmp_contents_path))
             try:
+                # this will throw a `TypeError` when the `tmp_contents_path` list is empty, then we `continue`
+                tmp_dir = os.path.join(directory, os.path.join(*tmp_contents_path))
+
                 if os.path.isdir(tmp_dir):
                     sys.path.append(tmp_dir)
                     return True


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
Fix `TypeError` in `update_sys_path` method. This PR allows running code below the standard Plex plugin directory, for example in a `docs` directory. This was broke in #17.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components
