### PR TITLE
fix: get correct ELEVATED_POLICY for check_port function

### DIFF
--- a/plexhints/_helpers.py
+++ b/plexhints/_helpers.py
@@ -13,7 +13,8 @@ import requests_cache
 from requests_cache import CachedSession
 
 # local imports
-from plexhints import ELEVATED_POLICY, GLOBAL_DEFAULT_TIMEOUT
+import plexhints
+from plexhints import GLOBAL_DEFAULT_TIMEOUT
 
 cookie_jar = RequestsCookieJar()
 session = CachedSession()
@@ -37,7 +38,7 @@ def check_port(url):
         If accessing a Plex server url and not using an elevated `PlexPluginCodePolicy` in the plist file.
         Plex Framework will raise ``Framework.exceptions.FrameworkException`` instead.
     """
-    if ':32400/' in url and not ELEVATED_POLICY:
+    if ':32400/' in url and not plexhints.ELEVATED_POLICY:
         raise Exception("Accessing the media server's HTTP interface is not permitted.")
 
 


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
Get the correct `ELEVATED_POLICY` value when running against an end point on the local Plex server.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
