### PR TITLE
build(deps): add plex plugins as submodule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -151,10 +151,7 @@ cython_debug/
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 .idea/
 
-# Plex-Plug-Ins
-# https://github.com/squaresmile/Plex-Plug-Ins
-Plex-Plug-Ins/
-
+# plexhints custom ignores
 plexhints/Data/
 plexhints/Preferences/
 

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "references/Plex-Plug-Ins"]
+	path = references/Plex-Plug-Ins
+	url = https://github.com/squaresmile/Plex-Plug-Ins.git
+	branch = master

--- a/README.md
+++ b/README.md
@@ -102,11 +102,8 @@ else:  # the code is running outside of Plex
 ```
 
 ## Developer References:
-A mirror of Plex's [Framework](https://github.com/squaresmile/Plex-Plug-Ins/tree/master/Framework.bundle/Contents/Resources/Versions/2/Python/Framework)
-
-```bash
-git clone https://github.com/squaresmile/Plex-Plug-Ins.git
-```
+A mirror of Plex's Framework is included as a submodule, which can be found
+[here](/references/Plex-Plug-Ins/Framework.bundle/Contents/Resources/Versions/2/Python/Framework)
 
 A snapshot of the original Plex developer [docs](https://web.archive.org/web/https://dev.plexapp.com/docs/index.html)
 


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
Adds upstream plex plugins as a submodule (only for reference)


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Dependency update (updates to dependencies)
- [x] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
