### PR TITLE
fix: adjust get default ip method to only use local addresses

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -328,7 +328,7 @@ runs:
         fi
 
         python \
-          -u scripts/plex-bootstraptest.py \
+          -u scripts/plex_bootstraptest.py \
           --destination plex \
           --advertise-ip 127.0.0.1 \
           --bootstrap-timeout ${{ inputs.bootstrap_timeout }} \

--- a/docs/source/contributing/testing.rst
+++ b/docs/source/contributing/testing.rst
@@ -90,7 +90,7 @@ A script is provided that allows you to prepare the Plex server for testing. Use
 Bootstrap the Plex server for testing
    .. code-block:: bash
 
-      python scripts/plex-bootstraptest.py --help
+      python scripts/plex_bootstraptest.py --help
 
 Test with pytest
    .. code-block:: bash

--- a/scripts/plex_bootstraptest.py
+++ b/scripts/plex_bootstraptest.py
@@ -252,9 +252,9 @@ def get_default_ip():
     # https://stackoverflow.com/questions/166506/finding-local-ip-addresses-using-pythons-stdlib
     s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
     s.settimeout(0)
+    s.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)
     try:
-        # doesn't even have to be reachable
-        s.connect(('10.254.254.254', 1))
+        s.connect(('<broadcast>', 0))
         ip = s.getsockname()[0]
     except Exception:
         ip = '127.0.0.1'


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
Slight adjustment to the `get_default_ip` method in the bootstrap test script.

Also, renames the script so that it can be imported.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [x] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
