### PR TITLE
fix(action): delay start of plex on macos

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -123,7 +123,7 @@ runs:
       working-directory: ${{ github.action_path }}
       run: |
         echo "::group::Build plist"
-        ${{ steps.venv.outputs.python-path }} ./scripts/build_plist.py
+        "${{ steps.venv.outputs.python-path }}" ./scripts/build_plist.py
         echo "::endgroup::"
 
     - name: Setup plexhints.bundle
@@ -143,10 +143,10 @@ runs:
       run: |
         echo "::group::Install Python Requirements"
         # install the plexhints library
-        ${{ steps.venv.outputs.python-path }} -m pip install -e .
+        "${{ steps.venv.outputs.python-path }}" -m pip install -e .
 
         # install requirements required for this action to complete
-        ${{ steps.venv.outputs.python-path }} -m pip install -r requirements-action.txt
+        "${{ steps.venv.outputs.python-path }}" -m pip install -r requirements-action.txt
         echo "::endgroup::"
 
     - name: Install Plex Media Server
@@ -193,8 +193,7 @@ runs:
           # https://forums.plex.tv/t/new-server-claiming-requirement-for-macos/816337
           defaults write com.plexapp.plexmediaserver enableLocalSecurity -bool FALSE
 
-          # start plex
-          open "/Applications/Plex Media Server.app"
+          # start plex after plugins are copied
         elif [[ "${{ runner.os }}" == "Linux" ]]; then
           app_data_path="/var/lib/plexmediaserver/Library/Application Support/Plex Media Server"
           plugin_path="${app_data_path}/Plug-ins"
@@ -354,7 +353,7 @@ runs:
           without_shows="--without-shows"
         fi
 
-        ${{ steps.venv.outputs.python-path }} \
+        "${{ steps.venv.outputs.python-path }}" \
           -u scripts/plex_bootstraptest.py \
           --destination plex \
           --advertise-ip 127.0.0.1 \


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
On macOS the plugins may fail to initialize if they are copied after Plex has already started.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
