### PR TITLE
fix(action): disable butler tasks on bootstrapped plex server

### DIFF
--- a/scripts/plex_bootstraptest.py
+++ b/scripts/plex_bootstraptest.py
@@ -16,6 +16,7 @@ from builtins import dict
 from builtins import input
 from builtins import range
 import argparse
+from datetime import datetime
 import os
 import re
 import shutil
@@ -557,6 +558,30 @@ if __name__ == "__main__":  # noqa: C901
     server.settings.get("GenerateBIFBehavior").set("never")
     server.settings.get("GenerateChapterThumbBehavior").set("never")
     server.settings.get("LoudnessAnalysisBehavior").set("never")
+    # disable butler tasks
+    current_hour = datetime.now().hour
+    new_hour12 = current_hour + 12
+    new_hour15 = current_hour + 15
+    if new_hour12 >= 24:
+        new_hour12 -= 24
+    if new_hour15 >= 24:
+        new_hour15 -= 24
+    server.settings.get("ButlerStartHour").set(new_hour12)
+    server.settings.get("ButlerEndHour").set(new_hour15)
+
+    # find all butler settings
+    butler_settings = []
+    for setting in server.settings.all():
+        if setting.id.lower().startswith("butler") and isinstance(setting.value, bool):
+            butler_settings.append(setting.id)
+    for setting in butler_settings:
+        try:
+            server.settings.get(setting).set(False)
+            print("Disabled setting '{}'".format(setting))
+        except NotFound:
+            print("Setting '{}' not found".format(setting))
+
+    # save settings
     server.settings.save()
 
     sections = []


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
Disable butler tasks on bootstrapped plex server.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
