### PR TITLE
ci: only publish pypi when release changes from pre-release to stable

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -152,36 +152,11 @@ jobs:
           echo "::endgroup::"
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: dist
           if-no-files-found: error  # 'warn' or 'ignore' are also available, defaults to `warn`
           path: dist
-
-  publish:
-    name: Publish
-    if: >-
-      (github.event_name == 'push' && github.ref == 'refs/heads/master') ||
-      (github.event_name == 'workflow_dispatch')
-    needs:
-      - setup_release
-      - build
-    runs-on: ubuntu-latest
-    environment:
-      name: publish
-      url: https://pypi.org/p/plexhints
-    permissions:
-      id-token: write
-    steps:
-      - name: Download dist artifacts
-        # this will be published to PyPI
-        uses: actions/download-artifact@v3
-        with:
-          name: dist
-          path: dist
-
-      - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
 
       - name: Create/Update GitHub Release
         if: ${{ needs.setup_release.outputs.publish_release == 'true' }}

--- a/.github/workflows/update-pypi.yml
+++ b/.github/workflows/update-pypi.yml
@@ -1,0 +1,39 @@
+---
+# Update pypi on release events.
+
+name: Update pypi
+
+on:
+  release:
+    types: [created, edited]
+  workflow_dispatch:
+
+concurrency:
+  group: "${{ github.workflow }}-${{ github.event.release.tag_name }}"
+  cancel-in-progress: true
+
+jobs:
+  update-pypi:
+    if: >-
+      !github.event.release.prerelease && !github.event.release.draft
+    runs-on: ubuntu-latest
+    environment:
+      name: publish
+      url: https://pypi.org/p/plexhints
+    permissions:
+      id-token: write
+    steps:
+      - name: Download release assets
+        id: download
+        uses: robinraju/release-downloader@v1.10
+        with:
+          repository: "${{ github.repository }}"
+          tag: "${{ github.event.release.tag_name }}"
+          fileName: "*"
+          tarBall: false
+          zipBall: false
+          out-file-path: "dist"
+          extract: false
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
After changing the pre-release logic, PyPI was still published in all cases. These changes make it so PyPI is only updated when the release is edited (e.g. from pre-release to stable).


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [x] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
