### PR TITLE
fix: ensure user prefs return correct values

### DIFF
--- a/plexhints/prefs_kit.py
+++ b/plexhints/prefs_kit.py
@@ -451,13 +451,14 @@ class _PreferenceSet(object):
             # Check for a value stored in the current context
             # raise an exception if a secure preference value couldn't be found
             # pref_values = self._sandbox.context.pref_values.get(self._identifier)
-            pref_values = self._prefs_dict
-            if pref_values:
-                if pref.secure is False or name in pref_values:  # this seems odd... should be and instead of or?
-                    value = pref.info_dict('')['value']
-                    found = True
-                else:
-                    raise Exception
+            # pref_values = self._prefs_dict
+            # if pref_values:
+            #     if pref.secure is False or name in pref_values:  # this seems odd... should be and instead of or?
+            #         value = pref_values.get(name)
+            #         print(value.__dict__)
+            #         found = True
+            #     else:
+            #         raise Exception
 
             # If we're not on the node, check for a user value.
             if not found and self._user_values:


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
If a value was set to a non default value, the prefs kit would still return the default value.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
