### PR TITLE
build(deps): pin lxml to python 2.7

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,13 +1,13 @@
 # version independent
 deprecation==2.1.0
 future==1.0.0
-lxml==4.9.4
 simplejson==3.19.2
 
 # version dependent
 BeautifulSoup4==4.9.3; python_version<"3"
 demjson==2.2.4; python_version<"3"
 feedparser==5.2.1; python_version<"3"
+lxml==4.9.4; python_version<"3"
 PyYAML==5.4.1; python_version<"3"
 requests==2.27.1; python_version<"3"
 requests-cache==0.5.2; python_version<"3"


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
lxml >= 5.1 do not support Python 2.7.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
