### PR TITLE
fix: ensure prefs_directory can be created recursively

### DIFF
--- a/plexhints/prefs_kit.py
+++ b/plexhints/prefs_kit.py
@@ -312,7 +312,7 @@ class _PreferenceSet(object):
         prefs_xml = _XML.StringFromElement(el=element)
         prefs_directory = os.path.join('plexhints', 'Preferences')
         if not os.path.isdir(prefs_directory):
-            os.mkdir(prefs_directory)
+            os.makedirs(prefs_directory)
         with open(self._user_file_path, mode='w+') as f:
             f.write(prefs_xml)
         _Log.Debug("Saved the user preferences")


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
Use `os.makedirs` instead of `os.mkdir`


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
